### PR TITLE
add ILAB Media Tools plugin (according to Wordfence)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,6 +63,7 @@
         "wpackagist-plugin/gdpr-cookie-compliance": ">=4.0,<4.0.3",
         "wpackagist-plugin/htaccess": "<1.8.2",
         "wpackagist-plugin/idx-broker-platinum": "<2.6.2",
+        "wpackagist-plugin/ilab-media-tools": "<=4.5.24",
         "wpackagist-plugin/import-users-from-csv-with-meta": "<1.15.0.1",
         "wpackagist-plugin/jetpack": ">=7.9,<7.9.1",
         "wpackagist-plugin/learnpress": "<3.2.6.8",


### PR DESCRIPTION
According to Wordfence ([this topic](https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/ilab-media-tools/media-cloud-for-amazon-s3-imgix-google-cloud-storage-digitalocean-spaces-and-more-4524-authenticated-contributor-stored-cross-site-scripting-via-shortcode)), ILAB Media Tools has a medium security vulnerability