### PR TITLE
FluentForm plugin <=5.1.16

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,6 +62,7 @@
         "wpackagist-plugin/flamingo": "<2.1.1",
         "wpackagist-plugin/flexible-checkout-fields": "<2.3.2",
         "wpackagist-plugin/font-awesome": "<4.0.0-rc17",
+        "wpackagist-plugin/fluentform": "<=5.1.16",
         "wpackagist-plugin/gallery-images-ape": ">=2.0,<2.0.7",
         "wpackagist-plugin/gboutique": "<=1.3",
         "wpackagist-plugin/gdpr-cookie-compliance": ">=4.0,<4.0.3",


### PR DESCRIPTION
[According to Wordfence](https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/fluentform/contact-form-plugin-by-fluent-forms-for-quiz-survey-and-drag-drop-wp-form-builder-5116-missing-authorization-to-settings-update-and-limited-privilege-escalation), `Contact Form Plugin by Fluent Forms for Quiz, Survey, and Drag & Drop WP Form Builder` plugin has a 9.8 CVSS security vulnerability below 5.1.17
