### PR TITLE
Aryo Activity Log plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "wpackagist-plugin/akismet": "<=2.0.1",
         "wpackagist-plugin/all-in-one-wp-migration": "<7.15",
         "wpackagist-plugin/appointment-booking-calendar": "<1.3.35",
+        "wpackagist-plugin/aryo-activity-log": "<=2.8.7",
         "wpackagist-plugin/async-javascript": "<2.20.02.27",
         "wpackagist-plugin/auth0": "<3.11.3",
         "wpackagist-plugin/awesome-support": "<=5.8.0",


### PR DESCRIPTION
According to [Wordfence](https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/aryo-activity-log/activity-log-287-ip-address-spoofing), Aryo Activity Log plugin has a 5.3 CVSS security vulnerability on versions <=2.8.7
Issue fixed on version 2.8.8
