### PR TITLE
Breadcrumb NavXT plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
         "wpackagist-plugin/bbpress-login-register-links-on-forum-topic-pages": ">=2,<2.8.5",
         "wpackagist-plugin/bbp-members-only": ">=1,<1.3.1",
         "wpackagist-plugin/blogtopdf": "<=1.0.2",
+        "wpackagist-plugin/breadcrumb-navxt": "<=6.1.0",
         "wpackagist-plugin/brizy": "<1.0.114",
         "wpackagist-plugin/buddypress-component-stats": "<=1.0",
         "wpackagist-plugin/calculated-fields-form": "<1.0.355",


### PR DESCRIPTION
According to [Wordfence](https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/breadcrumb-navxt/breadcrumb-navxt-610-sensitive-data-exposure), Breadcrumb NavXT has a 5.3 CVSS security vulnerability on versions <=6.1.0
Issue fixed on version 6.2.0
