### PR TITLE
Taxonomy Terms Order plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -102,6 +102,7 @@
         "wpackagist-plugin/seo-by-rank-math": "<1.0.41",
         "wpackagist-plugin/sitepress-multilingual-cms": "<4.3.7",
         "wpackagist-plugin/strong-testimonials": "<2.40.1",
+        "wpackagist-plugin/taxonomy-terms-order": "<1.5.3",
         "wpackagist-plugin/testimonial-free": "<2.2.0",
         "wpackagist-plugin/themegrill-demo-importer": "<1.6.3",
         "wpackagist-plugin/tutor": "<1.5.3",


### PR DESCRIPTION
According to [Wordfence](https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/taxonomy-terms-order/category-order-and-taxonomy-terms-order-1522-authenticated-php-object-injection), Category Order and Taxonomy Terms Order has a 8.5 CVSS security vulnerability on versions <1.5.3
Issue fixed on version 1.5.3
