### PR TITLE
WP Mail SMTP by WPForms plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -124,6 +124,7 @@
         "wpackagist-plugin/wp-ds-faq-plus": "<1.4.2",
         "wpackagist-plugin/wp-ecommerce-shop-styling": "<=2.9.1",
         "wpackagist-plugin/wp-file-upload": "<4.13.1",
+        "wpackagist-plugin/wp-mail-smtp": "<1.4.0",
         "wpackagist-plugin/wp-security-audit-log": "<4.0.2",
         "wpackagist-plugin/wp-simple-spreadsheet-fetcher-for-google": "<0.3.7",
         "wpackagist-plugin/xml-file-export-import-for-stampscom-and-woocommerce": "<1.1.9",


### PR DESCRIPTION
According to [Wordfence](https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/wp-mail-smtp/wp-mail-smtp-by-wpforms-133-unspecified-cross-site-scripting), WP Mail SMTP by WPForms has a 6.4 CVSS security vulnerability on versions <1.4.0
Issue fixed on version 1.4.0
