### PR TITLE
WP Super Cache plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -127,6 +127,7 @@
         "wpackagist-plugin/wp-mail-smtp": "<1.4.0",
         "wpackagist-plugin/wp-security-audit-log": "<4.0.2",
         "wpackagist-plugin/wp-simple-spreadsheet-fetcher-for-google": "<0.3.7",
+        "wpackagist-plugin/wp-super-cache": "<1.9",
         "wpackagist-plugin/xml-file-export-import-for-stampscom-and-woocommerce": "<1.1.9",
         "wpackagist-plugin/2j-slideshow": "<1.3.40",
         "wpackagist-theme/fruitful": "<3.8.2"


### PR DESCRIPTION
According to [Wordfence](https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/wp-super-cache/wp-super-cache-18-unauthenticated-cache-poisoning), WP Super Cache has a 6.5 CVSS security vulnerability on versions <1.9
Issue fixed on version 1.9
