### PR TITLE
Contact Form 7 plugin version bumped

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "wpackagist-plugin/cm-pop-up-banners": "<1.4.11",
         "wpackagist-plugin/code-snippets": "<2.14.0",
         "wpackagist-plugin/computer-repair-shop": "<2.0",
-        "wpackagist-plugin/contact-form-7": ">=5.0,<5.0.4",
+        "wpackagist-plugin/contact-form-7": "<5.9.2",
         "wpackagist-plugin/contextual-adminbar-color": "<0.3",
         "wpackagist-plugin/conversation-watson": "<0.8.21",
         "wpackagist-plugin/cookiebot": "<3.6.1",


### PR DESCRIPTION
According to [Wordfence](https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/contact-form-7/contact-form-7-59-reflected-cross-site-scripting), Contact Form 7 has a 6.1 CVSS security vulnerability on versions <=5.9
Issue fixed on version 5.9.2
