### PR TITLE
Like Button Rating ♥ LikeBtn plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -77,6 +77,7 @@
         "wpackagist-plugin/jetpack": ">=7.9,<7.9.1",
         "wpackagist-plugin/learnpress": "<3.2.6.8",
         "wpackagist-plugin/lifterlms": "<3.37.15",
+        "wpackagist-plugin/likebtn-like-button": "<=2.6.44",
         "wpackagist-plugin/miniorange-saml-20-single-sign-on": "<4.8.84",
         "wpackagist-plugin/modern-events-calendar-lite": ">=5,<5.1.8 || >=4,<4.9.5",
         "wpackagist-plugin/modula-best-grid-gallery": "<2.2.5",


### PR DESCRIPTION
According to [Wordfence](https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/likebtn-like-button/like-button-rating-likebtn-2644-arbitrary-e-mail-sending), Like Button Rating ♥ LikeBtn has a 5.0 CVSS security vulnerability on versions <=2.6.44
Issue fixed on version 2.6.45
