### PR TITLE
Relevanssi plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -98,6 +98,7 @@
         "wpackagist-plugin/product-lister-walmart": "<=1.0.1",
         "wpackagist-plugin/product-reviews-import-export-for-woocommerce": "<1.3.3",
         "wpackagist-plugin/profile-builder": "<3.1.1",
+        "wpackagist-plugin/relevanssi": "<=4.22.1",
         "wpackagist-plugin/rencontre": ">=3,<3.2.3",
         "wpackagist-plugin/resim-ara": "<=1.0",
         "wpackagist-plugin/responsive-add-ons": "<2.2.6",


### PR DESCRIPTION
According to [Wordfence](https://www.wordfence.com/threat-intel/vulnerabilities/detail/relevanssi-a-better-search-4221-unauthenticated-second-order-csv-injection), Relevanssi has a 5.8 CVSS security vulnerability on versions <=4.22.1
Issue fixed on version 4.22.2
