### PR TITLE
Checkout Field Editor plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -117,6 +117,7 @@
         "wpackagist-plugin/wd-google-maps": "<1.0.64",
         "wpackagist-plugin/web-portal-lite-client-portal-secure-file-sharing-private-messaging": "<=1.1.1",
         "wpackagist-plugin/woocommerce-conversion-tracking": "<2.0.6",
+        "wpackagist-plugin/woo-checkout-field-editor-pro": "<1.8.0",
         "wpackagist-plugin/wordpress-database-reset": "<3.15",
         "wpackagist-plugin/wordpress-seo": "<=22.6",
         "wpackagist-plugin/wpforms-lite": "<1.5.9",


### PR DESCRIPTION
According to [Wordfence](https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/woo-checkout-field-editor-pro/checkout-field-editor-172-authenticated-admin-php-object-injection), Checkout Field Editor has a 8.0 CVSS security vulnerability on versions <=1.7.2
Issue fixed on version 1.8.0
