### PR TITLE
ЮKassa для WooCommerce plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -116,6 +116,7 @@
         "wpackagist-plugin/videos-on-admin-dashboard": "<1.1.4",
         "wpackagist-plugin/wd-google-maps": "<1.0.64",
         "wpackagist-plugin/web-portal-lite-client-portal-secure-file-sharing-private-messaging": "<=1.1.1",
+        "wpackagist-plugin/woocommerce": "7.9.0",
         "wpackagist-plugin/woocommerce-conversion-tracking": "<2.0.6",
         "wpackagist-plugin/woo-checkout-field-editor-pro": "<1.8.0",
         "wpackagist-plugin/wordpress-database-reset": "<3.15",
@@ -134,6 +135,7 @@
         "wpackagist-plugin/wp-simple-spreadsheet-fetcher-for-google": "<0.3.7",
         "wpackagist-plugin/wp-super-cache": "<1.9",
         "wpackagist-plugin/xml-file-export-import-for-stampscom-and-woocommerce": "<1.1.9",
+        "wpackagist-plugin/yookassa": "<2.3.1",
         "wpackagist-plugin/2j-slideshow": "<1.3.40",
         "wpackagist-theme/fruitful": "<3.8.2"
     }


### PR DESCRIPTION
According to [Wordfence](https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/yookassa/yukassa-dlya-woocommerce-230-cross-site-request-forgery-to-settings-update), ЮKassa для WooCommerce has a 8.8 CVSS security vulnerability on versions <=2.3.0
Issue fixed on version 2.3.1
