### PR TITLE
Embed Plus Plugin for YouTube plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -136,6 +136,7 @@
         "wpackagist-plugin/wp-super-cache": "<1.9",
         "wpackagist-plugin/xml-file-export-import-for-stampscom-and-woocommerce": "<1.1.9",
         "wpackagist-plugin/yookassa": "<2.3.1",
+        "wpackagist-plugin/youtube-embed-plus": "<=11.8.1",
         "wpackagist-plugin/2j-slideshow": "<1.3.40",
         "wpackagist-theme/fruitful": "<3.8.2"
     }


### PR DESCRIPTION
According to [Wordfence](https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/youtube-embed-plus/embed-plus-plugin-for-youtube-1181-cross-site-request-forgery), Embed Plus Plugin for YouTube has a 6.5 CVSS security vulnerability on versions <=11.8.1
Issue fixed on version 11.8.2
