### PR TITLE
OAuth Single Sign On – SSO (OAuth Client) plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -79,6 +79,7 @@
         "wpackagist-plugin/lifterlms": "<3.37.15",
         "wpackagist-plugin/likebtn-like-button": "<=2.6.44",
         "wpackagist-plugin/meta-box": "<=5.9.3",
+        "wpackagist-plugin/miniorange-login-with-eve-online-google-facebook": "<6.24.2",
         "wpackagist-plugin/miniorange-saml-20-single-sign-on": "<4.8.84",
         "wpackagist-plugin/modern-events-calendar-lite": ">=5,<5.1.8 || >=4,<4.9.5",
         "wpackagist-plugin/modula-best-grid-gallery": "<2.2.5",


### PR DESCRIPTION
According to [Wordfence](https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/miniorange-login-with-eve-online-google-facebook/oauth-single-sign-on-sso-oauth-client-6241-cross-site-request-forgery-via-delete-in-mooauth-client-applist-page), OAuth Single Sign On – SSO (OAuth Client) has a 4.3 CVSS security vulnerability on versions <=6.24.1
Issue fixed on version 6.24.2
