### PR TITLE
Related Post plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -99,6 +99,7 @@
         "wpackagist-plugin/product-lister-walmart": "<=1.0.1",
         "wpackagist-plugin/product-reviews-import-export-for-woocommerce": "<1.3.3",
         "wpackagist-plugin/profile-builder": "<3.1.1",
+        "wpackagist-plugin/related-post": "<2.0.54",
         "wpackagist-plugin/relevanssi": "<=4.22.1",
         "wpackagist-plugin/rencontre": ">=3,<3.2.3",
         "wpackagist-plugin/resim-ara": "<=1.0",


### PR DESCRIPTION
According to [Wordfence](https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/related-post/related-post-2053-authenticated-contributor-stored-cross-site-scripting), Related Post has a 6.4 CVSS security vulnerability on versions <=2.0.53
Issue fixed on version 2.0.54
