### PR TITLE
Disable Comments plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,6 +55,7 @@
         "wpackagist-plugin/custom-registration-form-builder-with-submission-manager": "<4.6.0.4",
         "wpackagist-plugin/custom-searchable-data-entry-system": "<=1.7.1",
         "wpackagist-plugin/data-tables-generator-by-supsystic": "<1.9.92",
+        "wpackagist-plugin/disable-comments": "<1.0.4",
         "wpackagist-plugin/donorbox-donation-form": ">=7.1,<7.1.2",
         "wpackagist-plugin/duplicator": "<1.3.28",
         "wpackagist-plugin/easy-property-listings": "<3.4",


### PR DESCRIPTION
According to [Wordfence](https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/disable-comments/disable-comments-remove-comments-stop-spam-multi-site-support-104-cross-site-request-forgery), Disable Comments has a 8.8 CVSS security vulnerability on versions <1.0.4
Issue fixed on version 1.0.4
