### PR TITLE
Akismet version bumped

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "wpackagist-plugin/advanced-ads": "<1.17.4",
         "wpackagist-plugin/advanced-custom-fields": "<=6.2.4",
         "wpackagist-plugin/ajax-load-more": "<7.1.0",
-        "wpackagist-plugin/akismet": "<=2.0.1",
+        "wpackagist-plugin/akismet": "<3.1.5",
         "wpackagist-plugin/all-in-one-wp-migration": "<7.15",
         "wpackagist-plugin/appointment-booking-calendar": "<1.3.35",
         "wpackagist-plugin/aryo-activity-log": "<=2.8.7",


### PR DESCRIPTION
According to [Wordfence](https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/akismet/akismet-314-cross-site-scripting), Akismet has a 6.1 CVSS security vulnerability on versions <3.1.5
Issue fixed on version 3.1.5
