### PR TITLE
Vaultpress

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -116,6 +116,7 @@
         "wpackagist-plugin/ultimate-faqs": "<1.8.30",
         "wpackagist-plugin/ultimate-member": "<2.1.3",
         "wpackagist-plugin/users-customers-import-export-for-wp-woocommerce": "<1.3.9",
+        "wpackagist-plugin/vaultpress": "<=1.9",
         "wpackagist-plugin/videos-on-admin-dashboard": "<1.1.4",
         "wpackagist-plugin/wd-google-maps": "<1.0.64",
         "wpackagist-plugin/web-portal-lite-client-portal-secure-file-sharing-private-messaging": "<=1.1.1",


### PR DESCRIPTION
According to [Wordfence](https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/vaultpress/vaultpress-19-remote-code-execution), VaultPress has a 9.8 CVSS security vulnerability on versions <=1.9
Issue fixed on version 1.9.1
