### PR TITLE
Jetpack version bump

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -75,7 +75,7 @@
         "wpackagist-plugin/idx-broker-platinum": "<2.6.2",
         "wpackagist-plugin/ilab-media-tools": "<=4.5.24",
         "wpackagist-plugin/import-users-from-csv-with-meta": "<1.15.0.1",
-        "wpackagist-plugin/jetpack": ">=7.9,<7.9.1",
+        "wpackagist-plugin/jetpack": "<13.4",
         "wpackagist-plugin/learnpress": "<3.2.6.8",
         "wpackagist-plugin/lifterlms": "<3.37.15",
         "wpackagist-plugin/likebtn-like-button": "<=2.6.44",


### PR DESCRIPTION
According to [Wordfence](https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/jetpack/jetpack-wp-security-backup-speed-growth-1331-authenticated-contributor-stored-cross-site-scripting-via-wpvideo-shortcode), Jetpack – WP Security, Backup, Speed, & Growth has a 6.4 CVSS security vulnerability on versions <=13.3.1
Issue fixed on version 13.4
