### PR TITLE
Health Check & Troubleshooting

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -71,6 +71,7 @@
         "wpackagist-plugin/gallery-images-ape": ">=2.0,<2.0.7",
         "wpackagist-plugin/gboutique": "<=1.3",
         "wpackagist-plugin/gdpr-cookie-compliance": ">=4.0,<4.0.3",
+        "wpackagist-plugin/health-check": "<1.6.0",
         "wpackagist-plugin/htaccess": "<1.8.2",
         "wpackagist-plugin/idx-broker-platinum": "<2.6.2",
         "wpackagist-plugin/ilab-media-tools": "<=4.5.24",


### PR DESCRIPTION
According to [Wordfence](https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/health-check/health-check-troubleshooting-151-cross-site-request-forgery-via-health-check-troubleshoot-get-captures), Health Check & Troubleshooting has a 6.3 CVSS security vulnerability on versions <=1.5.1
Issue fixed on version 1.6.0
