### PR TITLE
BuddyPress

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,7 @@
         "wpackagist-plugin/blogtopdf": "<=1.0.2",
         "wpackagist-plugin/breadcrumb-navxt": "<=6.1.0",
         "wpackagist-plugin/brizy": "<1.0.114",
+        "wpackagist-plugin/buddypress": "<=12.4.0",
         "wpackagist-plugin/buddypress-component-stats": "<=1.0",
         "wpackagist-plugin/calculated-fields-form": "<1.0.355",
         "wpackagist-plugin/cardgate": "<3.1.16",


### PR DESCRIPTION
According to [Wordfence](https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/buddypress/buddypress-1240-authenticated-subscriber-stored-cross-site-scripting), BuddyPress has a 6.4 CVSS security vulnerability on versions <=12.4.0
Issue fixed on version 12.4.1
