### PR TITLE
Login with phone number

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -82,6 +82,7 @@
         "wpackagist-plugin/learnpress": "<3.2.6.8",
         "wpackagist-plugin/lifterlms": "<3.37.15",
         "wpackagist-plugin/likebtn-like-button": "<=2.6.44",
+        "wpackagist-plugin/login-with-phone-number": "<=1.7.26",
         "wpackagist-plugin/meta-box": "<=5.9.3",
         "wpackagist-plugin/miniorange-login-with-eve-online-google-facebook": "<6.24.2",
         "wpackagist-plugin/miniorange-saml-20-single-sign-on": "<4.8.84",


### PR DESCRIPTION
According to [Wordfence](https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/login-with-phone-number/login-with-phone-number-1726-authentication-bypass-due-to-missing-empty-value-check), Login with phone number has a 9.8 CVSS security vulnerability on versions <=1.7.26
Issue fixed on version 1.7.27
