### PR TITLE
WP STAGING WordPress Backup Plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -143,6 +143,7 @@
         "wpackagist-plugin/wp-mail-smtp": "<1.4.0",
         "wpackagist-plugin/wp-security-audit-log": "<4.0.2",
         "wpackagist-plugin/wp-simple-spreadsheet-fetcher-for-google": "<0.3.7",
+        "wpackagist-plugin/wp-staging": "<3.5.0",
         "wpackagist-plugin/wp-super-cache": "<1.9",
         "wpackagist-plugin/xml-file-export-import-for-stampscom-and-woocommerce": "<1.1.9",
         "wpackagist-plugin/yookassa": "<2.3.1",


### PR DESCRIPTION
According to [Wordfence](https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/wp-staging/wp-staging-wordpress-backup-plugin-migration-backup-restore-343-authenticated-admin-arbitrary-file-upload/), WP STAGING WordPress Backup Plugin – Migration Backup Restore has a 9.1 CVSS security vulnerability on versions <=3.4.3
Issue fixed on version 3.5.0
