### PR TITLE
WP Mail SMTP version bumped

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -140,7 +140,7 @@
         "wpackagist-plugin/wp-ds-faq-plus": "<1.4.2",
         "wpackagist-plugin/wp-ecommerce-shop-styling": "<=2.9.1",
         "wpackagist-plugin/wp-file-upload": "<4.13.1",
-        "wpackagist-plugin/wp-mail-smtp": "<1.4.0",
+        "wpackagist-plugin/wp-mail-smtp": "<=4.0.1",
         "wpackagist-plugin/wp-security-audit-log": "<4.0.2",
         "wpackagist-plugin/wp-simple-spreadsheet-fetcher-for-google": "<0.3.7",
         "wpackagist-plugin/wp-staging": "<3.5.0",


### PR DESCRIPTION
According to [Wordfence](https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/wp-mail-smtp/wp-mail-smtp-401-authenticated-admin-smtp-password-exposure), WP Mail SMTP has a 2.7 CVSS security vulnerability on versions <=4.0.1
Issue fixed on version 4.1.0
