### PR TITLE
Advanced Custom Fields <=6.3.8 CVSS 4.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "roots/wordpress":      ">=5.4,<5.4.2 || >=5.3,<5.3.1 || >=5.2,<5.2.5 || >=5.1,<5.1.4 || >=5.0,<5.0.8 || >=4.9,<4.9.13 || >=4.8,<4.8.12 || >=4.7,<4.7.16 || >=4.6,<4.6.17 || >=4.5,<4.5.20 || >=4.4,<4.4.21 || >=4.3,<4.3.22 || >=4.2,<4.2.26 || >=4.1,<4.1.29 || >=4.0,<4.0.29 || >=3.9,<3.9.30 || >=3.8,<3.8.32 || >=3.7,<3.7.32 || <3.7",
         "wpackagist-plugin/abstract-submission": "<=0.6",
         "wpackagist-plugin/advanced-ads": "<1.17.4",
-        "wpackagist-plugin/advanced-custom-fields": "<6.3.0",
+        "wpackagist-plugin/advanced-custom-fields": "<=6.3.8",
         "wpackagist-plugin/ajax-load-more": "<7.1.0",
         "wpackagist-plugin/akismet": "<3.1.5",
         "wpackagist-plugin/all-in-one-wp-migration": "<7.15",


### PR DESCRIPTION
According to [Wordfence](https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/advanced-custom-fields), Advanced Custom Fields/Secure Custom Fields has a 4.4 CVSS security vulnerability on versions <=6.3.8
Issue fixed on version 6.3.9
