### PR TITLE
Contact Form 7 <=5.9.4 CVSS 6.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "wpackagist-plugin/cm-pop-up-banners": "<1.4.11",
         "wpackagist-plugin/code-snippets": "<2.14.0",
         "wpackagist-plugin/computer-repair-shop": "<2.0",
-        "wpackagist-plugin/contact-form-7": "<5.9.2",
+        "wpackagist-plugin/contact-form-7": "<=5.9.4",
         "wpackagist-plugin/contextual-adminbar-color": "<0.3",
         "wpackagist-plugin/conversation-watson": "<0.8.21",
         "wpackagist-plugin/cookiebot": "<3.6.1",


### PR DESCRIPTION
According to [Wordfence](https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/contact-form-7/contact-form-7-594-unauthenticated-open-redirect), Contact Form 7 has a 6.1 CVSS security vulnerability on versions <=5.9.4
Issue fixed on version 5.9.5
