### PR TITLE
LikeBtn Button <=2.6.53 CVSS 6.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -82,7 +82,7 @@
         "wpackagist-plugin/jetpack": "<13.4",
         "wpackagist-plugin/learnpress": "<3.2.6.8",
         "wpackagist-plugin/lifterlms": "<3.37.15",
-        "wpackagist-plugin/likebtn-like-button": "<=2.6.44",
+        "wpackagist-plugin/likebtn-like-button": "<=2.6.53",
         "wpackagist-plugin/login-with-phone-number": "<=1.7.26",
         "wpackagist-plugin/meta-box": "<=5.9.3",
         "wpackagist-plugin/miniorange-login-with-eve-online-google-facebook": "<6.24.2",


### PR DESCRIPTION
According to [Wordfence](https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/likebtn-like-button/like-button-rating-2653-reflected-cross-site-scripting), LikeBtn Button has a 6.1 CVSS security vulnerability on versions <=2.6.53
Issue fixed on version 2.6.54
