### PR TITLE
MetaBox <=5.9.10 CVSS 4.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -84,7 +84,7 @@
         "wpackagist-plugin/lifterlms": "<3.37.15",
         "wpackagist-plugin/likebtn-like-button": "<=2.6.53",
         "wpackagist-plugin/login-with-phone-number": "<=1.7.26",
-        "wpackagist-plugin/meta-box": "<=5.9.3",
+        "wpackagist-plugin/meta-box": "<=5.9.10",
         "wpackagist-plugin/miniorange-login-with-eve-online-google-facebook": "<6.24.2",
         "wpackagist-plugin/miniorange-saml-20-single-sign-on": "<4.8.84",
         "wpackagist-plugin/modern-events-calendar-lite": ">=5,<5.1.8 || >=4,<4.9.5",


### PR DESCRIPTION
According to [Wordfence](https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/meta-box/meta-box-wordpress-custom-fields-framework-5910-missing-authorization-to-information-exposure), MetaBox has a 4.3 CVSS security vulnerability on versions <=5.9.10
Issue fixed on version 5.9.11
