### PR TITLE
Woocommerce Checkout Field Editor <=2.0.3 CVSS 4.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -128,7 +128,7 @@
         "wpackagist-plugin/web-portal-lite-client-portal-secure-file-sharing-private-messaging": "<=1.1.1",
         "wpackagist-plugin/woocommerce": "7.9.0",
         "wpackagist-plugin/woocommerce-conversion-tracking": "<2.0.6",
-        "wpackagist-plugin/woo-checkout-field-editor-pro": "<1.8.0",
+        "wpackagist-plugin/woo-checkout-field-editor-pro": "<=2.0.3",
         "wpackagist-plugin/wordpress-database-reset": "<3.15",
         "wpackagist-plugin/wordpress-seo": "<=22.6",
         "wpackagist-plugin/wpforms-lite": "<1.5.9",


### PR DESCRIPTION
According to [Wordfence](https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/woo-checkout-field-editor-pro/checkout-field-editor-checkout-manager-for-woocommerce-203-reflected-cross-site-scripting-via-render-review-request-notice), Woocommerce Checkout Field Editor has a 4.7 CVSS security vulnerability on versions <=2.0.3
Issue fixed on version 2.0.4
