### PR TITLE
Woocommerce <=9.1.2 CVSS 4.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -126,7 +126,7 @@
         "wpackagist-plugin/videos-on-admin-dashboard": "<1.1.4",
         "wpackagist-plugin/wd-google-maps": "<1.0.64",
         "wpackagist-plugin/web-portal-lite-client-portal-secure-file-sharing-private-messaging": "<=1.1.1",
-        "wpackagist-plugin/woocommerce": "7.9.0",
+        "wpackagist-plugin/woocommerce": "<=9.1.2",
         "wpackagist-plugin/woocommerce-conversion-tracking": "<2.0.6",
         "wpackagist-plugin/woo-checkout-field-editor-pro": "<=2.0.3",
         "wpackagist-plugin/wordpress-database-reset": "<3.15",


### PR DESCRIPTION
According to [Wordfence](https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/woocommerce/woocommerce-912-authenticated-administrator-stored-cross-site-scripting), Woocommerce has a 4.4 CVSS security vulnerability on versions <=9.1.2
Issue fixed on version 9.1.3
