### PR TITLE
Wordfence <=7.6.0 CVSS 4.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -129,6 +129,7 @@
         "wpackagist-plugin/woocommerce": "<=9.1.2",
         "wpackagist-plugin/woocommerce-conversion-tracking": "<2.0.6",
         "wpackagist-plugin/woo-checkout-field-editor-pro": "<=2.0.3",
+        "wpackagist-plugin/wordfence": "<=7.6.0",
         "wpackagist-plugin/wordpress-database-reset": "<3.15",
         "wpackagist-plugin/wordpress-seo": "<=22.6",
         "wpackagist-plugin/wpforms-lite": "<1.5.9",


### PR DESCRIPTION
According to [Wordfence](https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/wordfence/wordfence-security-firewall-malware-scan-760-authenticated-admin-stored-cross-site-scripting), Wordfence has a 4.4 CVSS security vulnerability on versions <=7.6.0
Issue fixed on version 7.6.1
