### PR TITLE
Jetpack <13.9.1 CVSS 4.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -79,7 +79,7 @@
         "wpackagist-plugin/idx-broker-platinum": "<2.6.2",
         "wpackagist-plugin/ilab-media-tools": "<=4.5.24",
         "wpackagist-plugin/import-users-from-csv-with-meta": "<1.15.0.1",
-        "wpackagist-plugin/jetpack": "<13.4",
+        "wpackagist-plugin/jetpack": "<13.9.1",
         "wpackagist-plugin/learnpress": "<3.2.6.8",
         "wpackagist-plugin/lifterlms": "<3.37.15",
         "wpackagist-plugin/likebtn-like-button": "<=2.6.53",


### PR DESCRIPTION
According to [Wordfence](https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/jetpack/jetpack-1391-missing-authorization-to-authenticated-subscriber-sensitive-information-disclosure), Jetpack has a 4.3 CVSS security vulnerability on versions <13.9.1
Issue fixed on version 13.9.1