### PR TITLE
BuddyPress <14.2.1 CVSS 8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "wpackagist-plugin/blogtopdf": "<=1.0.2",
         "wpackagist-plugin/breadcrumb-navxt": "<=6.1.0",
         "wpackagist-plugin/brizy": "<1.0.114",
-        "wpackagist-plugin/buddypress": "<=12.4.0",
+        "wpackagist-plugin/buddypress": "<14.2.1",
         "wpackagist-plugin/buddypress-component-stats": "<=1.0",
         "wpackagist-plugin/calculated-fields-form": "<1.0.355",
         "wpackagist-plugin/cardgate": "<3.1.16",


### PR DESCRIPTION
According to [Wordfence](https://www.wordfence.com/threat-intel/vulnerabilities/wordpress-plugins/buddypress/buddypress-1410-authenticated-subscriber-directory-traversal), BuddyPress has a 8.1 CVSS security vulnerability on versions <14.2.1
Issue fixed on version 14.2.1
