### PR TITLE
deps: WordPress critical vulnerability closed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,8 @@
         }
     ],
     "conflict": {
-        "johnpbloch/wordpress": "<=6.8.2",
-        "roots/wordpress": "<= 6.8.3.0 || >=6.9,<=6.9.1",
+        "johnpbloch/wordpress": "<= 6.8.5.0 || >=6.9,<=6.9.4 || >= 7.0,<=7.0.1",
+        "roots/wordpress": "<= 6.8.5.0 || >=6.9,<=6.9.4 || >= 7.0,<=7.0.1",
         "wpackagist-plugin/0-day-analytics": "<=4.0.0",
         "wpackagist-plugin/001-prime-strategy-translate-accelerator": "<=1.1.1",
         "wpackagist-plugin/012-ps-multi-languages": "<=1.6",


### PR DESCRIPTION
According to [this thread](https://github.com/WordPress/wordpress-develop/security/advisories/GHSA-ff9f-jf42-662q) and [this thread](http://github.com/WordPress/wordpress-develop/security/advisories/GHSA-fpp7-x2x2-2mjf), WP core has a moderate+critical severity security vulnerability on versions <=6.8.5 || >=6.9,<=6.9.4 || >=7.0,<=7.0.1
Issue fixed on version 6.8.6, 6.9.5, 7.0.2
